### PR TITLE
patch for C++11x

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -16,6 +16,7 @@
 #include <znc/IRCNetwork.h>
 #include <znc/Modules.h>
 #include <znc/FileUtils.h>
+#include <znc/Client.h>
 #include "time.h"
 #include <string.h>
 
@@ -445,7 +446,7 @@ class CPushMod : public CModule
 		 */
 		unsigned int client_count()
 		{
-			return user->GetUserClients().size();
+			return GetNetwork()->GetClients().size();
 		}
 
 		/**


### PR DESCRIPTION
it needs std:: for map and string to be compatible with C++11x
