### PR TITLE
Fixing thing I broke. Adding uri for pushover.

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -10,9 +10,6 @@
 
 #define REQUIRESSL
 
-#ifdef WIN_MSVC
-#include "stdafx.hpp"
-#endif
 #include "znc.h"
 #include "Chan.h"
 #include "User.h"
@@ -304,6 +301,11 @@ class CPushMod : public CModule
 				params["user"] = options["secret"];
 				params["title"] = title;
 				params["message"] = short_message;
+
+				if (uri != "")
+				{
+					params["url"] = uri;
+				}
 
 				if (options["target"] != "")
 				{


### PR DESCRIPTION
Oops, the #ifdef actually breaks it. I was compiling a different version of the file than I thought. Sorry.

Also, I added support for Pushover's URI. I suggest you add an option for URI Title, that Pushover supports, so that it doesn't say "Open tasker://andchat" in Pushover. If we pass the title, one could do this

```
set message_uri_title Open IRC App
```

And then, Pushover would display "Open IRC App" as the link, which could be clicked. Let me know if you'd like me to implement this please.
