### PR TITLE
Changed from <nick> to [nick] in OnChanMsg 

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -827,8 +827,8 @@ class CPushMod : public CModule
 			{
 				CString title = "Highlight";
 				CString msg = channel.GetName();
-				msg += ": <" + nick.GetNick();
-				msg += "> " + message;
+				msg += ": [" + nick.GetNick();
+				msg += "] " + message;
 
 				send_message(msg, title, channel.GetName());
 			}


### PR DESCRIPTION
Boxcar and other apps delete strings inside <> like IRC nicks, so changed to [nick] from <nick>. Without doing this, it was impossible to see the IRC nick of a channel message in Boxcar.
