### PR TITLE
Remove hardcoded pushover app key; use username/secert for user/token in...

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     User account that should receive push notifications.
 
-    This option must be set when using Boxcar or Notifo.
+    This option must be set when using Boxcar, Pushover or Notifo.
 
 *   `secret = ""`
 

--- a/push.cpp
+++ b/push.cpp
@@ -309,19 +309,22 @@ class CPushMod : public CModule
 			}
 			else if (service == "pushover")
 			{
-				if (options["secret"] == "")
+				if (options["username"] == "")
 				{
-					PutModule("Error: secret (user key) not set");
+					PutModule("Error: username (user key) not set");
 					return;
 				}
-
-				CString pushover_api_token = "h6RToHDU7gNnB3IMyUb94SuwKtBzOD";
+				if (options["secret"] == "")
+				{
+					PutModule("Error: secret (application token/key) not set");
+					return;
+				}
 
 				service_host = "api.pushover.net";
 				service_url = "/1/messages.json";
 
-				params["token"] = pushover_api_token;
-				params["user"] = options["secret"];
+				params["token"] = options["secret"];
+				params["user"] = options["username"];
 				params["title"] = message_title;
 				params["message"] = message_content;
 


### PR DESCRIPTION
This month (July), the pushover static app key reached it's msg limit of 25000 which is a shared limit among all users.  This patch removes the static key and uses the params 'username' and 'secret' as the user key and app key instead.

I've also confirmed this with Pushover.net support:

On Tue, 30 Jul 2013 at 11:33:38 -0500, Jake Watkins wrote:

> Did the ZNC-Push app reach its limit for all users this month (July)?
> 
> <*push> {"token":"invalid","errors":["application has exceeded current limit of 25000 messages"],"status":0,"request":"61104217b114a68e85e2d889a49ea8b0"}

Yes, each user should be registering their own API key to use and
get their own quota of 7500 notifications per month.

https://pushover.net/apps/build
