### PR TITLE
Fix pushbullet

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -260,7 +260,7 @@ class CPushMod : public CModule
 					return;
 				}
 
-				service_host = "www.pushbullet.com";
+				service_host = "api.pushbullet.com";
 				service_url = "/api/pushes";
 
 				// BASIC auth, base64-encoded APIKey:


### PR DESCRIPTION
Pushbullet gives a misleading error if the client uses
www.pushbullet.com instead of api.pushbullet.com. Whatever
the reason, using the correct hostname fixes it.
