### PR TITLE
Make nick highlights case insensitive.

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -640,6 +640,7 @@ class CPushMod : public CModule
 
 			VCString values;
 			options["highlight"].Split(" ", values, false);
+			values.push_back("%nick%");
 
 			for (VCString::iterator i = values.begin(); i != values.end(); i++)
 			{
@@ -673,13 +674,6 @@ class CPushMod : public CModule
 				{
 					return push;
 				}
-			}
-
-			CNick nick = user->GetNick();
-
-			if (message.find(nick.GetNick()) != std::string::npos)
-			{
-				return true;
 			}
 
 			return false;


### PR DESCRIPTION
I've noticed people typing my nick (which contains uppercase letters) all lowercase, and this doesn't trigger a push notification due to the nick check being case sensitive. This removes the find and makes %nick% implicitly part of the highlight variable which is always checked AsLower.
