### PR TITLE
ensure push.so is linked with libcurl properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 push.so: push.cpp
 	sed -i -e "s|PUSHVERSION \".*\"|PUSHVERSION \"$(version)\"|" push.cpp
-	CXXFLAGS="$(CXXFLAGS) $(flags)" znc-buildmod push.cpp
+	CXXFLAGS="$(CXXFLAGS) $(flags)" LIBS="$(LIBS) $(flags)" znc-buildmod push.cpp
 	sed -i -e "s|PUSHVERSION \".*\"|PUSHVERSION \"dev\"|" push.cpp
 
 install: push.so


### PR DESCRIPTION
It looks as if the push module was not actually linking against the libcurl
shared library without these additional flags being passed.
