### PR TITLE
don't base64 encode our pushbullet API key

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -277,7 +277,6 @@ class CPushMod : public CModule
 
 				// BASIC auth, base64-encoded APIKey:
 				service_auth = options["secret"] + CString(":");
-				service_auth.Base64Encode();
 				
 				// Pushbullet uses numeric device_id but they
 				// are transitioning to an alphanumeric device_iden


### PR DESCRIPTION
This causes Mysterious Failures and notification only works with it removed.
