### PR TITLE
Make it build with znc 0.206

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ else
 	flags=
 endif
 
+flags += $(shell echo '\#include <znc/IRCNetwork.h>' | gcc `znc-config --cflags` -E -x c++ /dev/stdin > /dev/null 2>/dev/null && echo -DHAVE_IRCNETWORK_H)
+
 push.so: push.cpp
 	sed -i -e "s|PUSHVERSION \".*\"|PUSHVERSION \"$(version)\"|" push.cpp
 	CXXFLAGS="$(CXXFLAGS) $(flags)" LIBS="$(LIBS) $(flags)" znc-buildmod push.cpp

--- a/push.cpp
+++ b/push.cpp
@@ -14,7 +14,6 @@
 #include <znc/znc.h>
 #include <znc/Chan.h>
 #include <znc/User.h>
-#include <znc/IRCNetwork.h>
 #include <znc/Modules.h>
 #include <znc/FileUtils.h>
 #include <znc/Client.h>
@@ -24,6 +23,10 @@
 #ifdef USE_CURL
 #include <curl/curl.h>
 #endif // USE_CURL
+
+#ifdef HAS_IRCNETWORK_H
+#include <znc/IRCNetwork.h>
+#endif // HAS_IRCNETWORK_H
 
 // Forward declaration
 class CPushMod;
@@ -106,6 +109,10 @@ class CPushMod : public CModule
 		// Configuration options
 		MCString options;
 		MCString defaults;
+
+#ifndef HAS_IRCNETWORK_H
+		CUser *GetNetwork() { return user; }
+#endif
 
 	public:
 
@@ -732,9 +739,9 @@ class CPushMod : public CModule
 				}
 
 				// Expand substrings like %nick%
-				if (m_pNetwork)
+				if (GetNetwork())
 				{
-					value = m_pNetwork->ExpandString(value);
+					value = GetNetwork()->ExpandString(value);
 				}
 				else
 				{
@@ -812,9 +819,9 @@ class CPushMod : public CModule
 				CString value;
 
 				// Expand substrings like %nick%
-				if (m_pNetwork)
+				if (GetNetwork())
 				{
-					value = m_pNetwork->ExpandString(*i);
+					value = GetNetwork()->ExpandString(*i);
 				}
 				else
 				{


### PR DESCRIPTION
Fixes #76.

I'm not proud of the IRCNetwork.h autodetection in the Makefile.  It probably requires GNU Make and GCC and Linux (for /dev/stdin).

It builds and loads (but only if I omit 'curl=yes' when I run make -- looks like a different bug). I can interact with it over IRC, but push notifications to PushBullet fail to work (probably also unrelated to ZNC version).
