### PR TITLE
URL service improvements:

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     This option must be set when using Boxcar or Pushover.
 
-    When using the custom URL service, if this option is set it will be used as username
-    for HTTP basic authentication.
+    When using the custom URL service, if this option is set it will enable HTTP basic
+    authentication and be used as username.
 
 *   `secret = ""`
 
@@ -245,8 +245,8 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty or PushBullet.
 
-    When using the custom URL service, if this option is set it will be used as password
-    for HTTP basic authentication.
+    When using the custom URL service, if this option is set it will enable HTTP basic
+    authentication and be used as password.
 
 *   `target = ""`
 

--- a/push.cpp
+++ b/push.cpp
@@ -476,7 +476,7 @@ class CPushMod : public CModule
 				}
 
 				// HTTP basic auth
-				if(options["username"] != "")
+				if(options["username"] != "" || options["secret"] != "")
 				{
 					service_auth = options["username"] + CString(":") + options["secret"];
 				}


### PR DESCRIPTION
Hi, I've added the following features to the URL service of znc-push:
- Support for POST method at user's preference
- Support for basic HTTP auth (uses "username" and "secret" options for username/password)
