### PR TITLE
Allow the user to set highlight without %nick%

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -140,7 +140,7 @@ class CPushMod : public CModule
 			// Notification conditions
 			defaults["away_only"] = "no";
 			defaults["client_count_less_than"] = "0";
-			defaults["highlight"] = "";
+			defaults["highlight"] = "%nick%";
 			defaults["idle"] = "0";
 			defaults["last_active"] = "180";
 			defaults["last_notification"] = "300";
@@ -739,7 +739,6 @@ class CPushMod : public CModule
 
 			VCString values;
 			options["highlight"].Split(" ", values, false);
-			values.push_back("%nick%");
 
 			for (VCString::iterator i = values.begin(); i != values.end(); i++)
 			{

--- a/push.cpp
+++ b/push.cpp
@@ -145,6 +145,7 @@ class CPushMod : public CModule
 			defaults["last_active"] = "180";
 			defaults["last_notification"] = "300";
 			defaults["nick_blacklist"] = "";
+			defaults["network_blacklist"] = "";
 			defaults["replied"] = "yes";
 			defaults["context"] = "*";
 
@@ -755,6 +756,7 @@ class CPushMod : public CModule
 				expr("last_active", last_active(context))
 				expr("last_notification", last_notification(context))
 				expr("nick_blacklist", nick_blacklist(nick))
+				expr("network_blacklist", network_blacklist())
 				expr("replied", replied(context))
 				expr("context", context_filter(context))
 
@@ -972,6 +974,30 @@ class CPushMod : public CModule
 
 			return true;
 		}
+		
+		/**
+		 * Check if the network_blacklist condition is met.
+		 *
+		 * @param network Network that the message was received on
+		 * @return True if network is not in the blacklist
+		 */
+		bool network_blacklist()
+		{
+			VCString blacklist;
+			options["network_blacklist"].Split(" ", blacklist, false);
+
+			CString name = (*m_pNetwork).GetName().AsLower();
+
+			for (VCString::iterator i = blacklist.begin(); i != blacklist.end(); i++)
+			{
+				if (name.WildCmp((*i).AsLower()))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
 
 		/**
 		 * Check if the replied condition is met.
@@ -1012,6 +1038,7 @@ class CPushMod : public CModule
 				&& last_active(context)
 				&& last_notification(context)
 				&& nick_blacklist(nick)
+				&& network_blacklist()
 				&& replied(context)
 				&& context_filter(context)
 				&& true;
@@ -1039,6 +1066,7 @@ class CPushMod : public CModule
 				&& last_active(context)
 				&& last_notification(context)
 				&& nick_blacklist(nick)
+				&& network_blacklist()
 				&& replied(context)
 				&& true;
 		}
@@ -1563,6 +1591,11 @@ class CPushMod : public CModule
 				table.AddRow();
 				table.SetCell("Condition", "idle");
 				table.SetCell("Status", CString(ago) + " seconds");
+				
+				table.AddRow();
+				table.SetCell("Condition", "network_blacklist");
+				// network_blacklist() is True if the network is not in a blacklist
+				table.SetCell("Status", network_blacklist() ? "no" : "yes");
 
 				if (token_count > 1)
 				{


### PR DESCRIPTION
My nick is `dan` on some networks - including german networks. `dann` is a common word in german so I get push notifications A LOT because %nick% highlights on `*dan*`.

I made `%nick%` the default highlight value and now the user can change it without having %nick% part of the value. This means I can do `_%nick% _%nick%:` or something like that. IMO this is a nicer way of handling this anyway - what else are default values for?
