### PR TITLE
Add support for airgram authenticated service

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     User account that should receive push notifications.
 
-    This option must be set when using Boxcar or Pushover.
+    This option must be set when using Boxcar or Pushover. For Airgram authenticated services, this is the service key.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as username.
@@ -249,7 +249,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     Authentication token for push notifications.
 
-    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty or PushBullet.
+    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty, Airgram authenticated services, or PushBullet.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as password.
@@ -261,7 +261,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     When using Pushover, this option allows you to specify a single device name to send
     notifications to; if blank or unset, notifications will be sent to all devices.
 
-    This option must be set when using PushBullet and Airgram. This module supports both `device_id` (older, numeric id) and the `device_iden` (newer, alphanumeric id) used by PushBullet. You can find your `device_iden` by navigating to a device page and noting the last part of the URL. 
+    This option must be set when using PushBullet and Airgram. This module supports both `device_id` (older, numeric id) and the `device_iden` (newer, alphanumeric id) used by PushBullet. You can find your `device_iden` by navigating to a device page and noting the last part of the URL. When using Airgram, this is the email address of the end user.
 
 
 ### Notifications

--- a/push.cpp
+++ b/push.cpp
@@ -540,7 +540,16 @@ class CPushMod : public CModule
 				}
 
 				service_host = "api.airgramapp.com";
-				service_url = "/1/send_as_guest";
+
+				if (options["username"] != "" && options["secret"] != "")
+				{
+					service_url = "/1/send";
+					service_auth = options["username"] + CString(":") + options["secret"];
+				}
+				else
+				{
+					service_url = "/1/send_as_guest";
+				}
 
 				params["email"] = options["target"];
 				params["msg"] = message_content;
@@ -1502,6 +1511,19 @@ class CPushMod : public CModule
 					service_url = "/devices/providers/" + boxcar_api_key + "/notifications/subscribe";
 
 					params["email"] = options["username"];
+				}
+				else if (service == "airgram")
+				{
+					if (options["username"] == "" || options["secret"] == "" || options["target"] == "")
+					{
+						PutModule("Error: target, username, and secret must be set");
+						return;
+					}
+
+					service_host = "api.airgramapp.com";
+					service_url = "/1/subscribe";
+					service_auth = options["username"] + CString(":") + options["secret"];
+					params["email"] = options["target"];
 				}
 				else
 				{


### PR DESCRIPTION
This adds support for airgram authenticated services without adding a new service type. If the username and secret are given, authenticated Airgram is used; if not, the current 'guest' method is used.
