### PR TITLE
Pushbullet: use type "link" when message_uri is set

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -284,8 +284,14 @@ class CPushMod : public CModule
 				{
 					params["device_iden"] = options["target"];
 				}
-
-				params["type"] = "note";
+				
+				if (message_uri == "")
+				{
+					params["type"] = "note";
+				} else {
+					params["type"] = "link";
+					params["url"] = message_uri;
+				}					
 				params["title"] = message_title;
 				params["body"] = message_content;
 			}


### PR DESCRIPTION
A small change that allows an application like tasker to open the irc application. 
