### PR TITLE
Respect pushover username and secret

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -316,13 +316,11 @@ class CPushMod : public CModule
 					return;
 				}
 
-				CString pushover_api_token = "h6RToHDU7gNnB3IMyUb94SuwKtBzOD";
-
 				service_host = "api.pushover.net";
 				service_url = "/1/messages.json";
 
-				params["token"] = pushover_api_token;
-				params["user"] = options["secret"];
+				params["user"] = options["username"];
+				params["token"] = options["secret"];
 				params["title"] = title;
 				params["message"] = short_message;
 


### PR DESCRIPTION
The pushover configuration on the legacy branch is all kinds of messed up.
1. The user key was hard-coded
2. When configured, the application token was being used as the user key
3. The hard-coded user key was being used as the application token

This has already been fixed in head, but needed correction in the legacy branch as well.
