### PR TITLE
Slack: Add title to the text itself and make it bold

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -614,7 +614,7 @@ class CPushMod : public CModule
 					params["username"] = options["username"];
 				}
 
-				params["payload"] = expand("{\"channel\": \"{target}\", \"pretext\": \"{title}\", \"text\": \"{message}\"}", replace);
+				params["payload"] = expand("{\"channel\": \"{target}\", \"text\": \"*{title}*: {message}\"}", replace);
 
 				PutDebug("payload: " + params["payload"]);
 			}


### PR DESCRIPTION
Previously I've used pretext to show title, but it was working not so good, so, I've decided just to prepend text with a bolded title, it looks much better.