### PR TITLE
`make install` no longer fails if .znc/modules does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ push.so: push.cpp
 	sed -i -e "s|PUSHVERSION \".*\"|PUSHVERSION \"dev\"|" push.cpp
 
 install: push.so
+	mkdir -p $(HOME)/.znc/modules/
 	cp push.so $(HOME)/.znc/modules/push.so
 
 clean:


### PR DESCRIPTION
As above.

Lots of users don't have the .znc/modules directory, so this creates it if it does not already exist so that the `make install` command suggested in the README actually works.