### PR TITLE
network-blacklist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     like "channelbot", "FooBot", or "Robot".  Care must be used to not accidentally
     blacklist legitimate nicks with wildcards.
 
+*   `network_blacklist` Default: ` `
+
+    Space-separated list of network names.
+    Notifications will only be sent for messages from networks that are not present in this
+    list, using a case-insensitive comparison.
+
 *   `replied` Default: `yes`
 
     If set to `yes`, notifications will only be sent if you have replied to the channel or

--- a/push.cpp
+++ b/push.cpp
@@ -145,6 +145,7 @@ class CPushMod : public CModule
 			defaults["last_active"] = "180";
 			defaults["last_notification"] = "300";
 			defaults["nick_blacklist"] = "";
+			defaults["network_blacklist"] = "";
 			defaults["replied"] = "yes";
 			defaults["context"] = "*";
 
@@ -755,6 +756,7 @@ class CPushMod : public CModule
 				expr("last_active", last_active(context))
 				expr("last_notification", last_notification(context))
 				expr("nick_blacklist", nick_blacklist(nick))
+				expr("network_blacklist", network_blacklist())
 				expr("replied", replied(context))
 				expr("context", context_filter(context))
 
@@ -973,6 +975,30 @@ class CPushMod : public CModule
 
 			return true;
 		}
+		
+		/**
+		 * Check if the network_blacklist condition is met.
+		 *
+		 * @param network Network that the message was received on
+		 * @return True if network is not in the blacklist
+		 */
+		bool network_blacklist()
+		{
+			VCString blacklist;
+			options["network_blacklist"].Split(" ", blacklist, false);
+
+			CString name = (*m_pNetwork).GetName().AsLower();
+
+			for (VCString::iterator i = blacklist.begin(); i != blacklist.end(); i++)
+			{
+				if (name.WildCmp((*i).AsLower()))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
 
 		/**
 		 * Check if the replied condition is met.
@@ -1013,6 +1039,7 @@ class CPushMod : public CModule
 				&& last_active(context)
 				&& last_notification(context)
 				&& nick_blacklist(nick)
+				&& network_blacklist()
 				&& replied(context)
 				&& context_filter(context)
 				&& true;
@@ -1040,6 +1067,7 @@ class CPushMod : public CModule
 				&& last_active(context)
 				&& last_notification(context)
 				&& nick_blacklist(nick)
+				&& network_blacklist()
 				&& replied(context)
 				&& true;
 		}
@@ -1564,6 +1592,11 @@ class CPushMod : public CModule
 				table.AddRow();
 				table.SetCell("Condition", "idle");
 				table.SetCell("Status", CString(ago) + " seconds");
+				
+				table.AddRow();
+				table.SetCell("Condition", "network_blacklist");
+				// network_blacklist() is True if the network is not in a blacklist
+				table.SetCell("Status", network_blacklist() ? "no" : "yes");
 
 				if (token_count > 1)
 				{


### PR DESCRIPTION
I added an option to blacklist networks, just like you can blacklist users. I have a few networks that I want to be notified about, and a few I don't feel like getting notifications all the time from (especially spammy ones). It would be cool if you could blacklist networks/channels/users in a `network:(channel|user)` format in the future, but for now it's really just a list of space-separated non-case-sensitive network names.