### PR TITLE
change handling of embedded version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version := $(shell git describe --dirty)
+version = $(shell git describe --dirty || echo dev)
 curl=no
 
 ifneq ($(curl),no)
@@ -7,10 +7,11 @@ else
 	flags=
 endif
 
+all: push.so
+
 push.so: push.cpp
-	sed -i "" -e "s|PUSHVERSION \".*\"|PUSHVERSION \"$(version)\"|" push.cpp
-	CXXFLAGS="$(CXXFLAGS) $(flags)" LIBS="$(LIBS) $(flags)" znc-buildmod push.cpp
-	sed -i "" -e "s|PUSHVERSION \".*\"|PUSHVERSION \"dev\"|" push.cpp
+	CXXFLAGS="$(CXXFLAGS) -DPUSHVERSION=\"$(version)\" $(flags)" LIBS="$(LIBS) $(flags)" \
+		 znc-buildmod push.cpp
 
 install: push.so
 	mkdir -p $(HOME)/.znc/modules/

--- a/push.cpp
+++ b/push.cpp
@@ -9,7 +9,9 @@
  */
 
 #define REQUIRESSL
+#ifndef PUSHVERSION
 #define PUSHVERSION "dev"
+#endif
 
 #include <znc/znc.h>
 #include <znc/Chan.h>


### PR DESCRIPTION
while building the znc-push module I realized at one point that `push.cpp` was
showing changes, even though I had not actually made any explicit changes to
the sources.  This was due to the editing of this file that happens as part of
the build process.

rather than modifying push.cpp as part of the build process, this
generates `version.h` and includes it in push.cpp.  This is cleaner
(does not lead to false changes in push.cpp) and makes it easier for a
packager to provide explicit version information.