### PR TITLE
Added note about installing ca-certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ be installed with:
 
     $ sudo aptitude install znc-dev
 
+In order for this plugin to properly work, you will need to ensure you have the `ca-certificates`
+package on Ubuntu based systems. This is required for push to properly verify the certificate
+of the service it's sending your message to.
+
+    $ sudo aptitude install ca-certificates
+
 Optionally, if you want to use libcurl for http requests, you also need to install cURL
 development header files.
 


### PR DESCRIPTION
I know there is a note about the default communication method not actually checking the certificate which is why libcurl is recommended. However, I just tested this without curl and it doesn't send anything without ca-certificates installed.

I followed your model of making examples use `aptitude` however, I might consider changing that in the future to `apt-get` just so newcomers don't sit there wondering what `aptitude` is ;)