### PR TITLE
Add Notify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ conditions.  ZNC Push current supports the following services:
 * [Nexmo][]
 * [Pushalot][]
 * [Pushjet][]
+* [Notify][]
 * Custom URL GET requests
 
 This project is still a Work In Progress, but should be functional enough and stable enough
@@ -249,6 +250,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     *   `airgram`
     *   `nexmo`
     *   `pushjet`
+    *   `notify`
     *   `url`
 
 *   `username` Default: ` `
@@ -264,7 +266,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     Authentication token for push notifications.
 
-    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty, Airgram authenticated services, PushBullet, Nexmo or Pushjet.
+    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty, Airgram authenticated services, PushBullet, Nexmo, Pushjet or Notify.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as password.
@@ -534,6 +536,7 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Nexmo]: https://www.nexmo.com
 [Pushalot]: https://pushalot.com/
 [Pushjet]: http://pushjet.io
+[Notify]: https://github.com/mashlol/notify
 
 [faq]: https://github.com/jreese/znc-push/blob/master/doc/faq.md
 [examples]: https://github.com/jreese/znc-push/blob/master/doc/examples.md


### PR DESCRIPTION
This PR adds support for [notify](https://github.com/mashlol/notify) to `znc-push`. In order to add support, I've implemented pass through of custom HTTP headers, in a fashion similar to how parameters are passed through.

Note that the two headers required for `notify` have been taken from the `notify.sh` script, which can be found at [https://github.com/mashlol/notify/blob/master/sh/notify.sh](https://github.com/mashlol/notify/blob/master/sh/notify.sh). These values _may_ change, and as such one possible improvement on this PR would be to make these values configurable, with the default being the current keys.

First C++ work in a while, but I don't think I've made a complete pigs ear of it. The changes appear to work, so thought I'd share it.

I'm open to absolutely any comments you have, of course.
