### PR TITLE
Add Notify support on Python branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ ZNC Push current supports the following services:
 * [Airgram][]
 * [Faast][]
 * [Yo][]
+* [Notify][]
 * Custom URL GET and POST requests
 
 This project is still a work in progress, but should be functional enough and
@@ -270,6 +271,7 @@ or `http://domain/{nick}/{unixtime}` to `http://domain/somenick/1299685136`.
     *   "airgram"
     *   "boxcar"
     *   "faast"
+    *   "notify"
     *   "nma"
     *   "prowl"
     *   "pushbullet"
@@ -287,7 +289,7 @@ or `http://domain/{nick}/{unixtime}` to `http://domain/somenick/1299685136`.
     Authentication token for push notifications.
 
     This option must be set when using Notify My Android, Pushover, Prowl,
-    Supertoasty, Airgram authenticated services, PushBullet or Yo.
+    Supertoasty, Airgram authenticated services, PushBullet, Yo or Notify.
 
     When using the custom URL service, if this option is set it will enable
     HTTP basic authentication and be used as password.
@@ -519,6 +521,7 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Airgram]: http://airgramapp.com/
 [Faast]: http://faast.io/
 [Yo]: https://www.justyo.co/
+[Notify]: https://github.com/mashlol/notify
 
 [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601 "ISO 8601 Date Format"
 

--- a/push.py
+++ b/push.py
@@ -1292,6 +1292,25 @@ class NMA(PushService):
 
         return Request('POST', url, data=params)
 
+class Notify(PushService):
+    required = {
+        'secret': 'secret',
+    }
+
+    def send(self, context):
+        url = 'https://api.parse.com/1/functions/notify'
+
+        params = {
+            'key': C.get('secret'),
+            'text': C.get_expanded('message_title') + ' ' + C.get_expanded('message_content'),
+        }
+
+        headers = {
+            'X-Parse-Application-Id': 'HQrMLZDevpTv2J1raSC6KATvlpNqqePPecUE0EgG',
+            'X-PArse-REST-API-Key': 'ivgV8ZoA0kyOOLWKms3M0wxYUxyUw4tfGgbj6DFd',
+        }
+
+        return Request('POST', url, data=params, headers=headers)
 
 class Prowl(PushService):
     required = {


### PR DESCRIPTION
This PR ports the functionality added in #184 to the Python branch, as recommended by @dgw.

As `notify` only allows you (to my knowledge) to provide a single string, I'm not sure if I'm passing enough information through with the message (title and body), but for my needs this will suffice.

Again, any input is welcomed with open arms :smile: 