### PR TITLE
Fix negative matching/filtering

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -880,6 +880,9 @@ class CPushMod : public CModule
 				char prefix = value[0];
 				bool push = true;
 
+				bool matched = false;
+				bool negated = false;
+
 				if (prefix == '-')
 				{
 					push = false;
@@ -904,11 +907,18 @@ class CPushMod : public CModule
 
 				if (msg.WildCmp(value))
 				{
-					return push;
+					if (push)
+					{
+						matched = true;
+					}
+					else
+					{
+						negated = true;
+					}
 				}
 			}
 
-			return false;
+			return (matched && !negated);
 		}
 
 		/**

--- a/push.cpp
+++ b/push.cpp
@@ -878,14 +878,14 @@ class CPushMod : public CModule
 			{
 				CString value = i->AsLower();
 				char prefix = value[0];
-				bool push = true;
+				bool negate_match = false;
 
 				bool matched = false;
 				bool negated = false;
 
 				if (prefix == '-')
 				{
-					push = false;
+					negate_match = true;
 					value.LeftChomp(1);
 				}
 				else if (prefix == '_')
@@ -907,13 +907,13 @@ class CPushMod : public CModule
 
 				if (msg.WildCmp(value))
 				{
-					if (push)
+					if (negate_match)
 					{
-						matched = true;
+						negated = true;
 					}
 					else
 					{
-						negated = true;
+						matched = true;
 					}
 				}
 			}


### PR DESCRIPTION
Previously, the highlight function returned true immediately upon finding any match, without checking whether any negative matches should be preventing the match.