### PR TITLE
Output debug messages for curl request

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -1850,12 +1850,18 @@ CURLcode make_curl_request(const CString& service_host, const CString& service_u
 	CURL *curl;
 	CURLcode result;
 
+	PutDebug("Building notification to " + service_host + service_url + "...");
+
 	curl = curl_easy_init();
 
 	CString user_agent = "ZNC Push/" + CString(PUSHVERSION);
 
+	PutDebug("User-Agent: " + user_agent);
+
 	CString url = CString(use_ssl ? "https" : "http") + "://" + service_host + service_url;
 	CString query = build_query_string(params);
+
+	PutDebug("Query string: " + query);
 
 	if (debug)
 	{
@@ -1892,6 +1898,8 @@ CURLcode make_curl_request(const CString& service_host, const CString& service_u
 	}
 
 	result = curl_easy_perform(curl);
+	PutDebug("Request sending");
+
 	curl_easy_cleanup(curl);
 
 	return result;


### PR DESCRIPTION
While testing out using curl vs socket, I realized that curl does not provide some of the debug messages that the socket does.

I do see that `CURLOPT_VERBOSE` is set, but that is not visible in the `*push` query.

I've tried to mimic the behavior of the socket method. The only thing that I am not putting out is the basic auth header. I am new to C++ so not sure how to output the string pointer instead of the `CString`. Any suggestion would be appreciated.