### PR TITLE
Invalid option name error on Show Me Everything

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -72,7 +72,7 @@ That's easy!
 ### Configuration
 
     channel_conditions: highlight and nick_blacklist
-    query_condition: nick_blacklist
+    query_conditions: nick_blacklist
 
     nick_blacklist: nickserv
 


### PR DESCRIPTION
Changed query_condition to query_conditions. 

set query_condition nick_blacklist
<*push> Error: invalid option name