### PR TITLE
Airgram has vanished from the face of the Internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ conditions.  ZNC Push current supports the following services:
 * [Prowl][]
 * [Supertoasty][]
 * [PushBullet][]
-* [Airgram][]
 * [Faast][]
 * [Nexmo][]
 * [Pushalot][]
@@ -125,7 +124,7 @@ and looking in your profile or settings:
     /msg *push set username foo
     /msg *push set secret ...
 
-If you're using Boxcar or Airgram, you need to use the following command to send a subscription request
+If you're using Boxcar, you need to use the following command to send a subscription request
 to your account, before ZNC Push can start working:
 
     /msg *push subscribe
@@ -247,7 +246,6 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     *   `prowl`
     *   `supertoasty`
     *   `pushbullet`
-    *   `airgram`
     *   `nexmo`
     *   `pushjet`
     *   `telegram`
@@ -257,7 +255,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     User account that should receive push notifications.
 
-    This option must be set when using Boxcar, or Pushover. For Airgram authenticated services and Nexmo, this is the service/api key.
+    This option must be set when using Boxcar or Pushover. For Nexmo, this is the service/api key.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as username.
@@ -266,7 +264,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     Authentication token for push notifications.
 
-    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty, Airgram authenticated services, PushBullet, Nexmo, Pushjet, or Telegram.
+    This option must be set when using Notify My Android, Pushover, Prowl, Supertoasty, PushBullet, Nexmo, Pushjet, or Telegram.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as password.
@@ -282,8 +280,6 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     When using Nexmo, this option allows you to specify the SMS destination
     number. The number must be in international format.
-
-    When using Airgram, this is the email address of the end user.
 
     When using Telegram, this is the id of the chat that receives the message.
 
@@ -533,7 +529,6 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Prowl]: http://www.prowlapp.com
 [Supertoasty]: http://www.supertoasty.com
 [PushBullet]: https://www.pushbullet.com/
-[Airgram]: http://airgramapp.com/
 [Faast]: http://faast.io/
 [Nexmo]: https://www.nexmo.com
 [Pushalot]: https://pushalot.com/

--- a/push.cpp
+++ b/push.cpp
@@ -605,26 +605,7 @@ class CPushMod : public CModule
 			}
 			else if (service == "airgram")
 			{
-				if (options["target"] == "")
-				{
-					PutModule("Error: target (email) not set");
-					return;
-				}
-
-				service_host = "api.airgramapp.com";
-
-				if (options["username"] != "" && options["secret"] != "")
-				{
-					service_url = "/1/send";
-					service_auth = options["username"] + CString(":") + options["secret"];
-				}
-				else
-				{
-					service_url = "/1/send_as_guest";
-				}
-
-				params["email"] = options["target"];
-				params["msg"] = message_content;
+				PutModule("Error: Airgram service shut down. Please configure another notification provider.");
 			}
 			else if (service == "slack")
 			{
@@ -1417,10 +1398,6 @@ class CPushMod : public CModule
 						{
 							PutModule("Note: URL requires setting the 'message_uri' option with the full URL");
 						}
-						else if (value == "airgram")
-						{
-							PutModule("Note: Airgram requires setting the 'target' with the email address of the recipient");
-						}
 						else if (value == "faast")
 						{
 							PutModule("Note: Faast requires setting the secret to your apikey");
@@ -1756,16 +1733,7 @@ class CPushMod : public CModule
 				}
 				else if (service == "airgram")
 				{
-					if (options["username"] == "" || options["secret"] == "" || options["target"] == "")
-					{
-						PutModule("Error: target, username, and secret must be set");
-						return;
-					}
-
-					service_host = "api.airgramapp.com";
-					service_url = "/1/subscribe";
-					service_auth = options["username"] + CString(":") + options["secret"];
-					params["email"] = options["target"];
+					PutModule("Error: Airgram service shut down. Please configure a different notification provider.");
 				}
 				else
 				{


### PR DESCRIPTION
Fixes #205 for the C++ module.

Before I tackle the Python version, I'd like to know two things from @jreese: 1) if moving to Python is still a goal and 2) if it's desirable to gracefully remove the service like this (vs. just deleting it with no fallback).