### PR TITLE
Add Slack to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ conditions.  ZNC Push current supports the following services:
 * [Pushalot][]
 * [Pushjet][]
 * [Telegram][]
+* [Slack][]
 * Custom URL GET requests
 
 This project is still a Work In Progress, but should be functional enough and stable enough
@@ -249,6 +250,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     *   `nexmo`
     *   `pushjet`
     *   `telegram`
+    *   `slack`
     *   `url`
 
 *   `username` Default: ` `
@@ -534,6 +536,7 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Pushalot]: https://pushalot.com/
 [Pushjet]: http://pushjet.io
 [Telegram]: https://telegram.org/
+[Slack]: https://slack.com/
 
 [faq]: https://github.com/jreese/znc-push/blob/master/doc/faq.md
 [examples]: https://github.com/jreese/znc-push/blob/master/doc/examples.md


### PR DESCRIPTION
Currently, Slack is supported by the codebase, but support for it is not
indicated in the README.

Help future readers by adding it to the readme as an officially
supported service.