### PR TITLE
Fix highlight match behaviour

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -869,9 +869,6 @@ class CPushMod : public CModule
 			options["highlight"].Split(" ", values, false);
 			values.push_back("%nick%");
 
-			bool matched = false;
-			bool negated = false;
-
 			for (VCString::iterator i = values.begin(); i != values.end(); i++)
 			{
 				CString value = i->AsLower();
@@ -902,18 +899,11 @@ class CPushMod : public CModule
 
 				if (msg.WildCmp(value))
 				{
-					if (negate_match)
-					{
-						negated = true;
-					}
-					else
-					{
-						matched = true;
-					}
+					return !negate_match;
 				}
 			}
 
-			return (matched && !negated);
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
Documentation states that, in the `highlight` field, both positive and negative matches terminate the search.
Currently, znc-push tests all strings for matches, with negations taking priority at the end.
This reduces the utility of the configuration field, especially with the implicit appending of `%nick%` which thus cannot be canceled out with `-%nick%`.

> Strings will be compared in order they appear in the configuration value, and the first string to match will end the search, meaning that earlier strings take priority over later values.
> [...]
> As an example, a highlight value of `-pinto car` will trigger notification on the message "I like cars", but will prevent notifications for "My favorite car is the Pinto" and "I like pinto beans". Conversely, a highlight value of `car -pinto` will trigger notifications for the first two messages, and only prevent notification of the last one.

This patch brings znc-push's behaviour in line with said documentation.