### PR TITLE
Add new option message_escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,16 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     When using Nexmo, this value is where the SMS is "from". In most cases, you must use a valid number in international format.
 
+*   `message_escape` Default: ` `
+
+    If set, keyword values will be escaped in this format before they are expanded in
+    `message_content`. Possible values are all that ZNC supports, most useful here will be
+    `HTML` or `URL`.
+
+    Note that the resulting string in `message_content` after keyword expansion will not be
+    escaped. If you need to escape characters for a service, you have to set the escaped
+    string to `message_content`.
+
 *   `message_uri` Default: ` `
 
     URI that will be sent with the push notification.  This could be a web address or a

--- a/doc/telegram.md
+++ b/doc/telegram.md
@@ -16,5 +16,12 @@ module by following the above steps.
 * set secret to the **api key**: <code>/msg *push set secret your-api-key</code>
 * set target to chat ID: <code>/msg *push set target your-chat-id</code>
 
+You can style your messages with [basic HTML][HTML] when you set the
+`message_escape` option accordingly.
+
+    set message_escape HTML
+    set message_content <i>{context}</i>: &lt;<b>{nick}</b>&gt; {message}
+
 [Telegram]: https://telegram.org
 [BotFather]: https://core.telegram.org/bots#6-botfather
+[HTML]: https://core.telegram.org/bots/api#formatting-options

--- a/push.cpp
+++ b/push.cpp
@@ -140,6 +140,7 @@ class CPushMod : public CModule
 			defaults["message_uri_title"] = "";
 			defaults["message_priority"] = "0";
 			defaults["message_sound"] = "";
+			defaults["message_escape"] = "";
 
 			// Notification conditions
 			defaults["away_only"] = "no";
@@ -266,6 +267,14 @@ class CPushMod : public CModule
 				replace["{network}"] = network->GetName();
 			} else {
 				replace["{network}"] = "(No network)";
+			}
+
+			if (options["message_escape"] != "")
+			{
+				CString::EEscape esc = CString::ToEscape(options["message_escape"]);
+				for (MCString::iterator i = replace.begin(); i != replace.end(); i++) {
+					i->second = i->second.Escape(esc);
+				}
 			}
 
 			CString message_uri = expand(options["message_uri"], replace);
@@ -728,6 +737,9 @@ class CPushMod : public CModule
 
 				params["chat_id"] = options["target"];
 				params["text"] = message_content;
+				if (options["message_escape"] == "HTML") {
+					params["parse_mode"] = "HTML";
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Allow to escape the keyword replacements before they are put into message_content with any of the ZNC supported formats. For example, this can be used to style messages with HTML for Telegram.

Please see the documentation in the commits for details.