### PR TITLE
Makefile - Escape version a bit more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 all: push.so
 
 push.so: push.cpp
-	CXXFLAGS="$(CXXFLAGS) -DPUSHVERSION=\"$(version)\" $(flags)" LIBS="$(LIBS) $(flags)" \
+	CXXFLAGS="$(CXXFLAGS) -DPUSHVERSION=\"\\\"$(version)\\\"\" $(flags)" LIBS="$(LIBS) $(flags)" \
 		 znc-buildmod push.cpp
 
 install: push.so


### PR DESCRIPTION
Closes #212 
Currently with the latest `master` version, the following happens:
```
❯ make curl=yes
CXXFLAGS=" -DPUSHVERSION=\"v1.0.0-163-gd2cf0d3\" -DUSE_CURL -lcurl" LIBS=" -DUSE_CURL -lcurl" \
         znc-buildmod push.cpp
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZNC 1.8.x
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmp_psb9r9p
make[1]: Entering directory '/tmp/tmp_psb9r9p'
make[2]: Entering directory '/tmp/tmp_psb9r9p'
make[3]: Entering directory '/tmp/tmp_psb9r9p'
Scanning dependencies of target module_push
make[3]: Leaving directory '/tmp/tmp_psb9r9p'
make[3]: Entering directory '/tmp/tmp_psb9r9p'
[ 50%] Building CXX object CMakeFiles/module_push.dir/home/jared/znc-push/push.cpp.o
<command-line>:0:15: error: too many decimal points in number
/home/jared/znc-push/push.cpp:1849:37: note: in expansion of macro ‘PUSHVERSION’
     PutModule("znc-push " + CString(PUSHVERSION));
                                     ^~~~~~~~~~~
<command-line>:0:15: error: too many decimal points in number
/home/jared/znc-push/push.cpp:1919:45: note: in expansion of macro ‘PUSHVERSION’
  CString user_agent = "ZNC Push/" + CString(PUSHVERSION);
                                             ^~~~~~~~~~~
/home/jared/znc-push/push.cpp: In member function ‘virtual void CPushMod::OnModCommand(const CString&)’:
<command-line>:0:13: error: ‘v1’ was not declared in this scope
/home/jared/znc-push/push.cpp:1849:37: note: in expansion of macro ‘PUSHVERSION’
     PutModule("znc-push " + CString(PUSHVERSION));
                                     ^~~~~~~~~~~
/home/jared/znc-push/push.cpp: In function ‘long int make_curl_request(const CString&, const CString&, const CString&, MCString&, int, bool, bool, const CString&, bool, bool)’:
<command-line>:0:13: error: ‘v1’ was not declared in this scope
/home/jared/znc-push/push.cpp:1919:45: note: in expansion of macro ‘PUSHVERSION’
  CString user_agent = "ZNC Push/" + CString(PUSHVERSION);
                                             ^~~~~~~~~~~
CMakeFiles/module_push.dir/build.make:62: recipe for target 'CMakeFiles/module_push.dir/home/jared/znc-push/push.cpp.o' failed
make[3]: *** [CMakeFiles/module_push.dir/home/jared/znc-push/push.cpp.o] Error 1
make[3]: Leaving directory '/tmp/tmp_psb9r9p'
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/module_push.dir/all' failed
make[2]: *** [CMakeFiles/module_push.dir/all] Error 2
make[2]: Leaving directory '/tmp/tmp_psb9r9p'
Makefile:83: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/tmp/tmp_psb9r9p'
Traceback (most recent call last):
  File "/usr/local/bin/znc-buildmod", line 89, in <module>
    subprocess.check_call(['cmake', '--build', '.'], cwd=build)
  File "/usr/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '--build', '.']' returned non-zero exit status 2
Makefile:13: recipe for target 'push.so' failed
make: *** [push.so] Error 1
```

And with this change:
```
❯ make curl=yes
CXXFLAGS=" -DPUSHVERSION=\"\\\"v1.0.0-163-gd2cf0d3-dirty\\\"\" -DUSE_CURL -lcurl" LIBS=" -DUSE_CURL -lcurl" \
         znc-buildmod push.cpp
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZNC 1.8.x
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmp7sax_b_a
make[1]: Entering directory '/tmp/tmp7sax_b_a'
make[2]: Entering directory '/tmp/tmp7sax_b_a'
make[3]: Entering directory '/tmp/tmp7sax_b_a'
Scanning dependencies of target module_push
make[3]: Leaving directory '/tmp/tmp7sax_b_a'
make[3]: Entering directory '/tmp/tmp7sax_b_a'
[ 50%] Building CXX object CMakeFiles/module_push.dir/home/jared/znc-push/push.cpp.o
[100%] Linking CXX shared module push.so
make[3]: Leaving directory '/tmp/tmp7sax_b_a'
[100%] Built target module_push
make[2]: Leaving directory '/tmp/tmp7sax_b_a'
make[1]: Leaving directory '/tmp/tmp7sax_b_a'
```

All credit for this tweak goes to @GRMrGecko from https://github.com/jreese/znc-push/issues/212#issuecomment-388156237 