### PR TITLE
Add Pushfleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ conditions.  ZNC Push current supports the following services:
 * [Prowl][]
 * [Supertoasty][]
 * [PushBullet][]
+* [Pushfleet][]
 * [Faast][]
 * [Nexmo][]
 * [Pushalot][]
@@ -249,6 +250,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     *   `prowl`
     *   `supertoasty`
     *   `pushbullet`
+    *   `pushfleet`
     *   `nexmo`
     *   `pushjet`
     *   `telegram`
@@ -269,7 +271,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 
     Authentication token for push notifications.
 
-    This option must be set when using Notify My Android, Pushover, Pushsafer, Prowl, Supertoasty, PushBullet, Nexmo, Pushjet, or Telegram.
+    This option must be set when using Notify My Android, Pushover, Pushsafer, Prowl, Supertoasty, PushBullet, Pushfleet, Nexmo, Pushjet, or Telegram.
 
     When using the custom URL service, if this option is set it will enable HTTP basic
     authentication and be used as password.
@@ -289,6 +291,8 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     When using Telegram, this is the id of the chat that receives the message.
 	
     When using Pushsafer, this is the id or group id of your devices.
+
+    When using Pushfleet, this is the user ID shown in your installed app.
 
 
 ### Notifications
@@ -545,6 +549,7 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Prowl]: http://www.prowlapp.com
 [Supertoasty]: http://www.supertoasty.com
 [PushBullet]: https://www.pushbullet.com/
+[Pushfleet]: https://pushfleet.com/
 [Faast]: http://faast.io/
 [Nexmo]: https://www.nexmo.com
 [Pushalot]: https://pushalot.com/

--- a/push.cpp
+++ b/push.cpp
@@ -340,6 +340,25 @@ class CPushMod : public CModule
 				params["notification[message]"] = message_content;
 				params["notification[source_url]"] = message_uri;
 			}
+			else if (service == "pushfleet")
+			{
+				if (options["target"] == "")
+				{
+					PutModule("Error: target user not set");
+					return;
+				}
+
+				CString pushfleet_appid = "A2BMJGZQ";
+
+				service_host = "pushfleet.com";
+				service_url = "/api/v1/send";
+				use_post = false;
+
+				params["appid"] = pushfleet_appid;
+				params["userid"] = options["target"];
+				params["message"] = message_content;
+				params["url"] = message_uri;
+			}
 			else if (service == "boxcar2")
 			{
 				if (options["secret"] == "")
@@ -1479,6 +1498,10 @@ class CPushMod : public CModule
 						if (value == "pushbullet")
 						{
 							PutModule("Note: Pushbullet requires setting both 'target' (to device id) and 'secret' (to api key) options");
+						}
+						else if (value == "pushfleet")
+						{
+							PutModule("Note: Pushfleet requires setting the 'target' option");
 						}
 						else if (value == "boxcar")
 						{

--- a/push.cpp
+++ b/push.cpp
@@ -347,14 +347,16 @@ class CPushMod : public CModule
 					PutModule("Error: target user not set");
 					return;
 				}
-
-				CString pushfleet_appid = "A2BMJGZQ";
+				if (options["secret"] == "")
+				{
+					PutModule("Error: secret (appid) not set");
+				}
 
 				service_host = "pushfleet.com";
 				service_url = "/api/v1/send";
 				use_post = false;
 
-				params["appid"] = pushfleet_appid;
+				params["appid"] = options["secret"];
 				params["userid"] = options["target"];
 				params["message"] = message_content;
 				params["url"] = message_uri;
@@ -1501,7 +1503,7 @@ class CPushMod : public CModule
 						}
 						else if (value == "pushfleet")
 						{
-							PutModule("Note: Pushfleet requires setting the 'target' option");
+							PutModule("Note: Pushfleet requires setting both 'target' (to user ID) and 'secret' (to app ID) options");
 						}
 						else if (value == "boxcar")
 						{


### PR DESCRIPTION
I'll be upfront about it: This is unlikely to be useful for new users, as the site consistently deletes new appids within a few hours, but users with existing appids might be able to use them with ZNC Push.

Pushfleet support has been completely unresponsive to repeated inquiries, despite claiming to respond "within 24 hours" in most cases. The service may be on life support at this point, not sure. A number of small things are broken on their site, not just the appid deletion thing. I found working on this patch fun over the last couple of weeks, but I'm not sure how useful it will be.

The only known issue (besides new appids getting deleted on the Pushfleet API console side) is that sending an empty `url` parameter to Pushfleet's API results in the notification coming back with the URL field set to a Google search for the notification message. Without any response from support I haven't been able to do anything about that.