### PR TITLE
Update Discord Webhook

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -667,7 +667,7 @@ class CPushMod : public CModule
 					return;
 				}
 
-				service_host = "discordapp.com";
+				service_host = "discord.com";
 				service_url = "/api/webhooks/" + options["secret"];
 
 				if (options["username"] != "")


### PR DESCRIPTION
the old domain will be shutdown November 7th, see https://github.com/discord/discord-api-docs/issues/1585