### PR TITLE
Add Igloo push support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ conditions.  ZNC Push current supports the following services:
 * [Telegram][]
 * [Slack][]
 * [Discord][]
+* [Igloo][]
 * Custom URL GET requests
 
 This project is still a Work In Progress, but should be functional enough and stable enough
@@ -252,6 +253,7 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
     *   `telegram`
     *   `slack`
     *   `discord`
+    *   `igloo`
     *   `url`
 
 *   `username` Default: ` `
@@ -549,6 +551,7 @@ from me and not from my employer.  See the `LICENSE` file for details.
 [Telegram]: https://telegram.org/
 [Slack]: https://slack.com/
 [Discord]: https://discord.gg
+[Igloo]: https://iglooirc.com/
 
 [faq]: https://github.com/jreese/znc-push/blob/master/doc/faq.md
 [examples]: https://github.com/jreese/znc-push/blob/master/doc/examples.md

--- a/push.cpp
+++ b/push.cpp
@@ -229,7 +229,7 @@ class CPushMod : public CModule
 		 * @param title Message title to use
 		 * @param context Channel or nick context
 		 */
-		void send_message(const CString& message, const CString& title="New Message", const CString& context="*push", const CNick& nick=CString("*push"))
+		void send_message(const CString& message, const CString& title="New Message", const CString& context="*push", const CNick& nick=CString("*push"), const CString& type="")
 		{
 			// Set the last notification time
 			last_notification_time[context] = time(NULL);
@@ -482,6 +482,29 @@ class CPushMod : public CModule
 				params["event"] = message_title;
 				params["description"] = message_content;
 				params["url"] = message_uri;
+			}
+			else if (service == "igloo")
+			{
+				if (options["target"] == "")
+				{
+					PutModule("Error: no devices are set");
+					return;
+				}
+
+				service_host = "api.iglooirc.com";
+				service_url = "/znc/push";
+
+				if (network != NULL)
+				{
+					params["network"] = network->GetName();
+					params["nick"] = network->GetNick();
+				}
+
+				params["sender"] = nick.GetNick();
+				params["channel"] = context;
+				params["message"] = message;
+				params["type"] = type;
+				params["device1"] = options["target"];
 			}
 			else if (service == "supertoasty")
 			{
@@ -1234,7 +1257,7 @@ class CPushMod : public CModule
 			{
 				CString title = "Highlight";
 
-				send_message(message, title, channel.GetName(), nick);
+				send_message(message, title, channel.GetName(), nick, "action");
 			}
 
 			return CONTINUE;
@@ -1253,7 +1276,7 @@ class CPushMod : public CModule
 			{
 				CString title = "Channel Notice";
 
-				send_message(message, title, channel.GetName(), nick);
+				send_message(message, title, channel.GetName(), nick, "notice");
 			}
 
 			return CONTINUE;
@@ -1289,7 +1312,7 @@ class CPushMod : public CModule
 			{
 				CString title = "Private Message";
 
-				send_message(message, title, nick.GetNick(), nick);
+				send_message(message, title, nick.GetNick(), nick, "action");
 			}
 
 			return CONTINUE;
@@ -1307,7 +1330,7 @@ class CPushMod : public CModule
 			{
 				CString title = "Private Notice";
 
-				send_message(message, title, nick.GetNick(), nick);
+				send_message(message, title, nick.GetNick(), nick, "notice");
 			}
 
 			return CONTINUE;
@@ -1472,6 +1495,10 @@ class CPushMod : public CModule
 						else if (value == "prowl")
 						{
 							PutModule("Note: Prowl requires setting the 'secret' option");
+						}
+						else if (value == "igloo")
+						{
+							PutModule("Note: Igloo requires adding your device with 'target'");
 						}
 						else if (value == "supertoasty")
 						{


### PR DESCRIPTION
Add support for the [Igloo Client](https://iglooirc.com/) push service. The client author [forked](https://git.jordanko.ch/Igloo/Push) the module and added support in the fork but I don't see any irreconcilable differences between the two modules so this just merges them. This also fixes a segfault in the Igloo code.