### PR TITLE
Add Igloo support for second device

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ to something similar to "http://domain/#channel/2011-03-09 14:25:09", or
 	
     When using Pushsafer, this is the id or group id of your devices.
 
+*   `extra_target` Default: ` `
+
+    Second device or target name for push notifications.
+
+    Currently only Igloo supports this option. Can be used to send
+    notifications to up to two devices at the same time.
+
 
 ### Notifications
 

--- a/push.cpp
+++ b/push.cpp
@@ -130,6 +130,7 @@ class CPushMod : public CModule
 			defaults["username"] = "";
 			defaults["secret"] = "";
 			defaults["target"] = "";
+			defaults["extra_target"] = "";
 
 			// Notification settings
 			defaults["message_content"] = "{context}: [{nick}] {message}";
@@ -261,6 +262,7 @@ class CPushMod : public CModule
 			replace["{username}"] = options["username"];
 			replace["{secret}"] = options["secret"];
 			replace["{target}"] = options["target"];
+			replace["{extra_target}"] = options["extra_target"];
 			// network is special because it can be nullptr if the user has none set up yet
 			CIRCNetwork* network = GetNetwork();
 			if (network) {
@@ -505,6 +507,11 @@ class CPushMod : public CModule
 				params["message"] = message;
 				params["type"] = type;
 				params["device1"] = options["target"];
+
+				if (options["extra_target"] != "")
+				{
+					params["device2"] = options["extra_target"];
+				}
 			}
 			else if (service == "supertoasty")
 			{
@@ -1498,7 +1505,7 @@ class CPushMod : public CModule
 						}
 						else if (value == "igloo")
 						{
-							PutModule("Note: Igloo requires adding your device with 'target'");
+							PutModule("Note: Igloo requires adding your device with 'target'. An extra device can be added with 'extra_target'.");
 						}
 						else if (value == "supertoasty")
 						{


### PR DESCRIPTION
The Igloo push service supports simultaneous push to multiple devices. This patch allows for a second device.